### PR TITLE
Forwarding outline tokens to chained steps

### DIFF
--- a/src/Moodle/BehatExtension/Tester/MoodleScenarioTester.php
+++ b/src/Moodle/BehatExtension/Tester/MoodleScenarioTester.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Moodle\BehatExtension\Tester;
+
+use Behat\Behat\Tester\ScenarioTester;
+
+use Behat\Gherkin\Node\ScenarioNode,
+    Behat\Gherkin\Node\StepNode;
+
+use Behat\Behat\Context\ContextInterface;
+
+
+/**
+ * ScenarioTester extension.
+ *
+ * Allows outlines to pass it's examples
+ * to the step tester so chained steps
+ * can correctly display the used tokens.
+ *
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class MoodleScenarioTester extends ScenarioTester
+{
+
+    /**
+     * @var bool ScenarioTester::skip is marked as private.
+     */
+    private $moodleskip;
+
+    /**
+     * Sets tester to dry-run mode.
+     *
+     * Extended to set an attribute that
+     * MoodleScenarioTester can access.
+     *
+     * @param Boolean $skip
+     */
+    public function setSkip($skip = true)
+    {
+        $this->skip = (bool) $skip;
+        $this->moodleskip = $this->skip;
+    }
+
+    /**
+     * Visits & tests StepNode.
+     *
+     * Simple ScenarioTester::visitStep() extension just
+     * calling StepTester::setExampleTokens()
+     *
+     * @param StepNode         $step          step instance
+     * @param ScenarioNode     $logicalParent logical parent of the step
+     * @param ContextInterface $context       context instance
+     * @param array            $tokens        step replacements for tokens
+     * @param boolean          $skip          mark step as skipped?
+     *
+     * @see StepTester::visit()
+     *
+     * @return integer
+     */
+    protected function visitStep(StepNode $step, ScenarioNode $logicalParent,
+                                 ContextInterface $context, array $tokens = array(), $skip = false)
+    {
+        if ($logicalParent instanceof OutlineNode) {
+            $step = $step->createExampleRowStep($tokens);
+        }
+
+        $tester = $this->container->get('behat.tester.step');
+        $tester->setLogicalParent($logicalParent);
+        $tester->setContext($context);
+        $tester->skip($skip || $this->moodleskip);
+
+        // Attaching tokens for chained steps.
+        $tester->setExampleTokens($tokens);
+
+        return $step->accept($tester);
+    }
+
+}

--- a/src/Moodle/BehatExtension/Tester/MoodleStepTester.php
+++ b/src/Moodle/BehatExtension/Tester/MoodleStepTester.php
@@ -6,6 +6,7 @@ use Behat\Behat\Tester\StepTester,
     Behat\Behat\Event\StepEvent,
     Behat\Behat\Definition\DefinitionInterface,
     Behat\Behat\Context\ContextInterface,
+    Behat\Gherkin\Node\OutlineNode,
     Behat\Behat\Context\Step\SubstepInterface,
     Behat\Gherkin\Node\AbstractNode,
     Behat\Gherkin\Node\StepNode,
@@ -56,6 +57,13 @@ class MoodleStepTester extends StepTester
     private $moodlelogicalParent;
 
     /**
+     * Tokens in case of running a outline example.
+     *
+     * @var array
+     */
+    private $tokens = array();
+
+    /**
      * We only dispatch the after step event when a "final" step has been reached.
      *
      * @var bool
@@ -104,6 +112,17 @@ class MoodleStepTester extends StepTester
     {
         $this->moodlelogicalParent = $parent;
         parent::setLogicalParent($parent);
+    }
+
+    /**
+     * Sets the example tokens if they exists.
+     *
+     * @param array $tokens
+     * @return void
+     */
+    public function setExampleTokens($tokens)
+    {
+        $this->tokens = $tokens;
     }
 
     /**
@@ -234,8 +253,14 @@ class MoodleStepTester extends StepTester
         $chain = is_array($chain) ? $chain : array($chain);
         foreach ($chain as $chainItem) {
             if ($chainItem instanceof SubstepInterface) {
+
                 $substepNode = $chainItem->getStepNode();
                 $substepNode->setParent($step->getParent());
+
+                // Replace by tokens when needed.
+                if ($substepNode->getParent() instanceof OutlineNode) {
+                    $substepNode = $substepNode->createExampleRowStep($this->tokens);
+                }
 
                 $this->dispatchafterstep = false;
 

--- a/src/Moodle/BehatExtension/services/core.xml
+++ b/src/Moodle/BehatExtension/services/core.xml
@@ -10,6 +10,7 @@
         <parameter key="moodle.context.initializer.class">Moodle\BehatExtension\Context\Initializer\MoodleAwareInitializer</parameter>
         <parameter key="behat.help_printer.definitions.class">Moodle\BehatExtension\HelpPrinter\MoodleDefinitionsPrinter</parameter>
         <parameter key="behat.tester.step.class">Moodle\BehatExtension\Tester\MoodleStepTester</parameter>
+        <parameter key="behat.tester.scenario.class">Moodle\BehatExtension\Tester\MoodleScenarioTester</parameter>
     </parameters>
     <services>
 


### PR DESCRIPTION
When running scenario outlines the examples data
were not passed to the chained steps, this resulted
in unexpected exceptions when outputs formatters
processes them.
