### PR TITLE
MDL-48356 moodle_formatter: don't use any core stuff on dry runs

### DIFF
--- a/src/Moodle/BehatExtension/Formatter/MoodleProgressFormatter.php
+++ b/src/Moodle/BehatExtension/Formatter/MoodleProgressFormatter.php
@@ -47,6 +47,23 @@ class MoodleProgressFormatter extends ProgressFormatter
     {
         global $CFG;
 
+        // NO $CFG, surely a dry-run, let's try to find config.php using passed dirroot.
+        if (empty($CFG)) {
+            $params = $event->getContextParameters();
+            if (!isset($params['dirroot'])) {
+                return; // No param, nothing to do.
+            }
+
+            $configpath = $params['dirroot'] . '/config.php';
+            if (!file_exists($configpath) or !is_readable($configpath)) {
+                return; // No config.php, nothing to do.
+            }
+
+            // Have found a readable config.php, add it.
+            define('CLI_SCRIPT', true);
+            require_once($configpath);
+        }
+
         require_once($CFG->dirroot . '/lib/behat/classes/util.php');
 
         $browser = \Moodle\BehatExtension\Driver\MoodleSelenium2Driver::getBrowser();


### PR DESCRIPTION
Note that this only happens when the executions are --dry-run,
normally CFG and other core stuff is available.

So, with this patch, we look for the passed "dirroot" parameter and
use it to include config.php. If it's not available for any reason
we just skip the hook execution and done.

Finally, in order to get this working ok, we must pass dirroot via context parameters, that's achieved by:

https://github.com/stronk7/moodle/commit/90152505a70b720cf4310ff6dc144f36a64422f4

(if dirroot is not available, the formatter will also work, just won't include specific information about the run)

Ciao :-)