### PR TITLE
MDL-50116 behat: updated symfony/symfony version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "behat/mink-extension": "1.2.0",
         "behat/mink-goutte-driver": "1.0.9",
         "behat/mink-selenium2-driver": "1.1.1",
-        "symfony/symfony": "2.4.4",
+        "symfony/symfony": "2.4.10",
         "guzzlehttp/guzzle": "~3.1"
     },
     "autoload": {


### PR DESCRIPTION
DomCrawler 2.4.4 is causing importNode warnings, because of libxml2
updated symfony/symfony, which in turn update symfony/dom-crawler to
avoid the warning on php versions using libxml2