### PR TITLE
MDL-52685 behat: keep doctrine/cache at 1.5.x for PHP 5.4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "behat/mink-selenium2-driver": "1.1.1",
         "symfony/symfony": "2.4.10",
         "doctrine/common": "2.5.0",
+        "doctrine/cache": "1.5.*",
         "guzzlehttp/guzzle": "~3.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,12 @@
         "behat/mink-goutte-driver": "1.0.9",
         "behat/mink-selenium2-driver": "1.1.1",
         "symfony/symfony": "2.4.10",
-        "doctrine/common": "2.5.0",
-        "doctrine/cache": "1.5.*",
         "guzzlehttp/guzzle": "~3.1"
+    },
+    "config": {
+      "platform": {
+        "php": "5.4.4"
+      }
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Should resolve https://tracker.moodle.org/browse/MDL-52685; unclear on proper testing procedure.
