### PR TITLE
Fix undefined RuntimeException

### DIFF
--- a/src/Moodle/BehatExtension/Context/ContextClass/ClassResolver.php
+++ b/src/Moodle/BehatExtension/Context/ContextClass/ClassResolver.php
@@ -68,7 +68,7 @@ final class ClassResolver implements Resolver {
      */
     public function resolveClass($contextclass) {
         if (!is_array($this->moodlebehatcontexts)) {
-            throw new RuntimeException('There are no Moodle context with steps definitions');
+            throw new \RuntimeException('There are no Moodle context with steps definitions');
         }
 
         // Using the key as context identifier load context class.
@@ -76,7 +76,7 @@ final class ClassResolver implements Resolver {
             (file_exists($this->moodlebehatcontexts[$contextclass]))) {
             require_once($this->moodlebehatcontexts[$contextclass]);
         } else {
-            throw new RuntimeException('Moodle behat context "'.$contextclass.'" not found');
+            throw new \RuntimeException('Moodle behat context "'.$contextclass.'" not found');
         }
         return $contextclass;
     }


### PR DESCRIPTION
I got this error:

    Fatal error: Uncaught Error: Class 'Moodle\BehatExtension\Context\ContextClass\RuntimeException' not found in vendor/moodlehq/behat-extension/src/Moodle/BehatExtension/Context/ContextClass/ClassResolver.php:79

Just need to add backslashes on the RuntimeException for the class to resolve.