### PR TITLE
MDL-66945 behat: Ensure nodes are visible before clicking

### DIFF
--- a/src/Moodle/BehatExtension/Driver/MoodleSelenium2Driver.php
+++ b/src/Moodle/BehatExtension/Driver/MoodleSelenium2Driver.php
@@ -4,6 +4,8 @@ namespace Moodle\BehatExtension\Driver;
 
 use Behat\Mink\Driver\Selenium2Driver as Selenium2Driver;
 use WebDriver\Key as key;
+use Moodle\BehatExtension\Element\NodeElement;
+use Behat\Mink\Session;
 
 /**
  * Selenium2 driver extension to allow extra selenium capabilities restricted by behat/mink-extension.
@@ -16,6 +18,21 @@ class MoodleSelenium2Driver extends Selenium2Driver
      * @var string
      */
     protected static $browser;
+
+    /**
+     * @var Session The Mink Session
+     */
+    private $session;
+
+    /**
+     * Set the session in the driver.
+     */
+    public function setSession(Session $session) {
+        $this->session = $session;
+
+        // The parent also stores the session.
+        parent::setSession($session);
+    }
 
     /**
      * Instantiates the driver.
@@ -265,5 +282,21 @@ JS;
     public function post_key($key, $xpath) {
         $element = $this->getWebDriverSession()->element('xpath', $xpath);
         $element->postValue(array('value' => array($key)));
+    }
+
+    /**
+     * Find any Element at the specified xpath.
+     *
+     * @param string $xpath The xpath to search for
+     * @return NodeElement[]
+     */
+    public function find($xpath) {
+        $elements = array();
+
+        foreach ($this->findElementXpaths($xpath) as $xpath) {
+            $elements[] = new NodeElement($xpath, $this->session);
+        }
+
+        return $elements;
     }
 }

--- a/src/Moodle/BehatExtension/Element/NodeElement.php
+++ b/src/Moodle/BehatExtension/Element/NodeElement.php
@@ -1,0 +1,94 @@
+<?php
+// This file is part of the Moodle Behat extension - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Node Element.
+ *
+ * @package    moodlehq-behat-extension
+ * @copyright  2019 Andrew Nicols <andrew@nicols.co.uk>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace Moodle\BehatExtension\Element;
+
+use Behat\Mink\Element\NodeElement as MinkNodeElement;
+
+/**
+ * Node Element.
+ *
+ * @package    moodlehq-behat-extension
+ * @copyright  2019 Andrew Nicols <andrew@nicols.co.uk>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class NodeElement extends MinkNodeElement {
+    /**
+     * Click the current node.
+     *
+     * This implementation includes a fix for Firefox on Ubuntu 1804 to ensure that the clicked node is visible before
+     * it is clicked.
+     */
+    public function click() {
+        $browser = \Moodle\BehatExtension\Driver\MoodleSelenium2Driver::getBrowser();
+        if (in_array(strtolower($browser), ['firefox'])) {
+            $this->ensure_node_is_in_viewport();
+        }
+
+        parent::click();
+    }
+
+
+    /**
+     * Attempt to ensure that the node is in the viewport given a margin of error.
+     *
+     * This ensures that the top is below the top of the viewport, and the bottom is above the bottom of the viewport.
+     * It does not handle the following cases:
+     * - Where the node is bigger than the viewport
+     * - Where the node is covered by another element.
+     * - Where the node is to the left or right of the viewport
+     *
+     * @param int $margin A margin aroudn th
+     */
+    public function ensure_node_is_in_viewport(int $margin = 20) {
+        $xpath = $this->getXPath();
+        $xpathsubs = [
+            "\r\n" => " ",
+            "\r" => " ",
+            "\n" => " ",
+            '"' => '\"',
+        ];
+        $xpath = str_replace(array_keys($xpathsubs), array_values($xpathsubs), $this->getXpath());
+        // Fetch the node by xpath, then check that the top is below the top of the document, and the bottom is below
+        // the bottom of the document.
+        // Note: This does not handle the case where the item being clicked is bigger than the window. Nor does it
+        // handle the case where the node is covered by another element.
+        $js = <<<EOF
+(function() {
+    var node = document.evaluate("{$xpath}", document, null, XPathResult.ANY_TYPE, null).iterateNext();
+    function isVisible(element) {
+        var margin = {$margin};
+        var rect = element.getBoundingClientRect();
+        var viewHeight = Math.max(document.documentElement.clientHeight, window.innerHeight);
+        return !(rect.top < 0 + margin || (rect.bottom - viewHeight >= 0 - margin));
+    }
+
+    if (node && !isVisible(node)) {
+        node.scrollIntoView();
+    }
+})();
+EOF;
+        $this->getSession()->executeScript($js);
+    }
+}

--- a/src/Moodle/BehatExtension/Output/Printer/MoodleProgressPrinter.php
+++ b/src/Moodle/BehatExtension/Output/Printer/MoodleProgressPrinter.php
@@ -95,7 +95,7 @@ final class MoodleProgressPrinter implements SetupPrinter {
         // Calling all directly from here as we avoid more behat framework extensions.
         $runinfo = \behat_util::get_site_info();
         $runinfo .= 'Server OS "' . PHP_OS . '"' . ', Browser: "' . $browser . '"' . PHP_EOL;
-        if (in_array(strtolower($browser), array('chrome', 'safari', 'iexplore'))) {
+        if (in_array(strtolower($browser), ['chrome','firefox'])) {
             $runinfo .= 'Browser specific fixes have been applied. See http://docs.moodle.org/dev/Acceptance_testing#Browser_specific_fixes' .  PHP_EOL;
         }
         $runinfo .= 'Started at ' . date('d-m-Y, H:i', time());


### PR DESCRIPTION
It seems that some change to Ubuntu, which I haven't yet pinned down, has changed how a 'click' works.

If the element is not quite on screen, then clicking on the link only sets the focus and brings it into visibility.

My initial solution was to solve this in Moodle having the `i_click_on` step call a step which calls `scrollIntoView` to ensure that the node is on screen.

Sadly it turns out that this affects other places too where we are calling `->click()` directly.

We have two options therefore...
1. find every location that we call `NodeElement->click()` and add a call beforehand to the new `scroll_into_view` step.
2. extend the `NodeElement` in the behat extension and have the `click` call do the work instead

Since this is a browser-issue related to driver I've gone for option 2.
Note: I am not massively keen on the fact that we have to do so. This will of course be 'fixed' (I really hope) with the move to using a W3C compatible Firefox... but we still have no ETA on that option.

Here are some builds against 36:

Firefox: [![Build Status](https://ci.moodle.org/buildStatus/icon?job=DEV.03+-+Developer-requested+Behat+with+app+support&build=29)](https://ci.moodle.org/view/Testing/job/DEV.03%20-%20Developer-requested%20Behat%20with%20app%20support/29/)
Chrome: [![Build Status](https://ci.moodle.org/buildStatus/icon?job=DEV.03+-+Developer-requested+Behat+with+app+support&build=30)](https://ci.moodle.org/view/Testing/job/DEV.03%20-%20Developer-requested%20Behat%20with%20app%20support/30/)

When these pass I'll backport the Moodle component to other branches and launch more jobs.