### PR TITLE
MDL-67317 mink: Bump behat/mink for php74 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=7.2.0",
-        "behat/mink": "~1.7",
+        "behat/mink": "~1.8",
         "behat/mink-extension": "~2.2",
         "behat/mink-goutte-driver": "~1.2",
         "behat/mink-selenium2-driver": "~1.3",


### PR DESCRIPTION
Bumping to 1.8.x (from current 1.7.x). It just comes with
a little difference about how sessions aren't auto-created
any more. That will be implemented @ core. See the tracker
issue for more information.

Note: Once this is accepted, I'll be tagging it in order to make core to point to it.
Note2: I also have observed that we are running slightly outdated behat/driver versions... after this... will try to bump behat to current 3.6.x and see how everything goes.