### PR TITLE
Bump to Behat 3.6.x (38_STABLE)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
     "require": {
         "php": ">=7.1.0",
         "behat/mink": "~1.8",
-        "behat/mink-extension": "~2.2",
+        "behat/mink-extension": "~2.3",
         "behat/mink-goutte-driver": "~1.2",
-        "behat/mink-selenium2-driver": "~1.3",
-        "symfony/process": "2.8.*",
-        "behat/behat": "3.5.*"
+        "behat/mink-selenium2-driver": "~1.4",
+        "symfony/process": "^4.0 || ^5.0",
+        "behat/behat": "3.6.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Moodle/BehatExtension/EventDispatcher/Tester/ChainedStepTester.php
+++ b/src/Moodle/BehatExtension/EventDispatcher/Tester/ChainedStepTester.php
@@ -35,6 +35,7 @@ use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Testwork\Call\CallResult;
 use Behat\Testwork\Environment\Environment;
+use Behat\Testwork\EventDispatcher\TestworkEventDispatcher;
 use Behat\Behat\EventDispatcher\Event\AfterStepSetup;
 use Behat\Behat\EventDispatcher\Event\AfterStepTested;
 use Behat\Behat\EventDispatcher\Event\BeforeStepTeardown;
@@ -186,24 +187,48 @@ class ChainedStepTester implements StepTester {
         foreach ($steps as $step) {
             // Setup new step.
             $event = new BeforeStepTested($env, $feature, $step);
-            $this->eventDispatcher->dispatch($event::BEFORE, $event);
+            if (TestworkEventDispatcher::DISPATCHER_VERSION === 2) {
+                // Symfony 4.3 and up.
+                $this->eventDispatcher->dispatch($event, $event::BEFORE);
+            } else {
+                // TODO: Remove when our min supported version is >= 4.3.
+                $this->eventDispatcher->dispatch($event::BEFORE, $event);
+            }
 
             $setup = $this->setUp($env, $feature, $step, $skip);
 
             $event = new AfterStepSetup($env, $feature, $step, $setup);
-            $this->eventDispatcher->dispatch($event::AFTER_SETUP, $event);
+            if (TestworkEventDispatcher::DISPATCHER_VERSION === 2) {
+                // Symfony 4.3 and up.
+                $this->eventDispatcher->dispatch($event, $event::AFTER_SETUP);
+            } else {
+                // TODO: Remove when our min supported version is >= 4.3.
+                $this->eventDispatcher->dispatch($event::AFTER_SETUP, $event);
+            }
 
             // Test it.
             $stepResult = $this->test($env, $feature, $step, $skip);
 
             // Tear down.
             $event = new BeforeStepTeardown($env, $feature, $step, $result);
-            $this->eventDispatcher->dispatch($event::BEFORE_TEARDOWN, $event);
+            if (TestworkEventDispatcher::DISPATCHER_VERSION === 2) {
+                // Symfony 4.3 and up.
+                $this->eventDispatcher->dispatch($event, $event::BEFORE_TEARDOWN);
+            } else {
+                // TODO: Remove when our min supported version is >= 4.3.
+                $this->eventDispatcher->dispatch($event::BEFORE_TEARDOWN, $event);
+            }
 
             $teardown = $this->tearDown($env, $feature, $step, $skip, $result);
 
             $event = new AfterStepTested($env, $feature, $step, $result, $teardown);
-            $this->eventDispatcher->dispatch($event::AFTER, $event);
+            if (TestworkEventDispatcher::DISPATCHER_VERSION === 2) {
+                // Symfony 4.3 and up.
+                $this->eventDispatcher->dispatch($event, $event::AFTER);
+            } else {
+                // TODO: Remove when our min supported version is >= 4.3.
+                $this->eventDispatcher->dispatch($event::AFTER, $event);
+            }
 
             //
             if (!$stepResult->isPassed()) {

--- a/src/Moodle/BehatExtension/EventDispatcher/Tester/MoodleEventDispatchingStepTester.php
+++ b/src/Moodle/BehatExtension/EventDispatcher/Tester/MoodleEventDispatchingStepTester.php
@@ -34,6 +34,7 @@ use Behat\Behat\Tester\StepTester;
 use Behat\Gherkin\Node\FeatureNode;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Testwork\Environment\Environment;
+use Behat\Testwork\EventDispatcher\TestworkEventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -70,13 +71,25 @@ final class MoodleEventDispatchingStepTester implements StepTester
      */
     public function setUp(Environment $env, FeatureNode $feature, StepNode $step, $skip) {
         $event = new BeforeStepTested($env, $feature, $step);
-        $this->eventDispatcher->dispatch($event::BEFORE, $event);
+        if (TestworkEventDispatcher::DISPATCHER_VERSION === 2) {
+            // Symfony 4.3 and up.
+            $this->eventDispatcher->dispatch($event, $event::BEFORE);
+        } else {
+            // TODO: Remove when our min supported version is >= 4.3.
+            $this->eventDispatcher->dispatch($event::BEFORE, $event);
+        }
 
         $setup = $this->baseTester->setUp($env, $feature, $step, $skip);
         $this->baseTester->setEventDispatcher($this->eventDispatcher);
 
         $event = new AfterStepSetup($env, $feature, $step, $setup);
-        $this->eventDispatcher->dispatch($event::AFTER_SETUP, $event);
+        if (TestworkEventDispatcher::DISPATCHER_VERSION === 2) {
+            // Symfony 4.3 and up.
+            $this->eventDispatcher->dispatch($event, $event::AFTER_SETUP);
+        } else {
+            // TODO: Remove when our min supported version is >= 4.3.
+            $this->eventDispatcher->dispatch($event::AFTER_SETUP, $event);
+        }
 
         return $setup;
     }
@@ -93,12 +106,24 @@ final class MoodleEventDispatchingStepTester implements StepTester
      */
     public function tearDown(Environment $env, FeatureNode $feature, StepNode $step, $skip, StepResult $result) {
         $event = new BeforeStepTeardown($env, $feature, $step, $result);
-        $this->eventDispatcher->dispatch($event::BEFORE_TEARDOWN, $event);
+        if (TestworkEventDispatcher::DISPATCHER_VERSION === 2) {
+            // Symfony 4.3 and up.
+            $this->eventDispatcher->dispatch($event, $event::BEFORE_TEARDOWN);
+        } else {
+            // TODO: Remove when our min supported version is >= 4.3.
+            $this->eventDispatcher->dispatch($event::BEFORE_TEARDOWN, $event);
+        }
 
         $teardown = $this->baseTester->tearDown($env, $feature, $step, $skip, $result);
 
         $event = new AfterStepTested($env, $feature, $step, $result, $teardown);
-        $this->eventDispatcher->dispatch($event::AFTER, $event);
+        if (TestworkEventDispatcher::DISPATCHER_VERSION === 2) {
+            // Symfony 4.3 and up.
+            $this->eventDispatcher->dispatch($event, $event::AFTER);
+        } else {
+            // TODO: Remove when our min supported version is >= 4.3.
+            $this->eventDispatcher->dispatch($event::AFTER, $event);
+        }
 
         return $teardown;
     }


### PR DESCRIPTION
This bumps behat to current behat 3.6.x and also some dependencies.

Special mention to get Symfony 5.x support into a couple of components, both via conditional code:

- Dispatcher (user by all behat hooks).
- Process (needed for parallel runs).

So, this new version is working ok for any Symfony >= 4.0 version.

That implies that the min PHP version supported is 7.1, hence this bump only can be applied to Moodle 3.7 and up (older versions work with PHP 7.0).

Tracker link: https://tracker.moodle.org/browse/MDL-68445