### PR TITLE
Show the real fail in pretty results

### DIFF
--- a/src/Moodle/BehatExtension/EventDispatcher/Tester/ChainedStepTester.php
+++ b/src/Moodle/BehatExtension/EventDispatcher/Tester/ChainedStepTester.php
@@ -125,7 +125,13 @@ class ChainedStepTester implements StepTester {
             // Extra step, looking for a moodle exception, a debugging() message or a PHP debug message.
             $checkingStep = new StepNode('Given', self::EXCEPTIONS_STEP_TEXT, array(), $step->getLine());
             $afterExceptionCheckingEvent = $this->singlesteptester->test($env, $feature, $checkingStep, $skip);
-            return $this->checkSkipResult($afterExceptionCheckingEvent);
+            $exceptionCheckResult = $this->checkSkipResult($afterExceptionCheckingEvent);
+
+            if (!$exceptionCheckResult->isPassed()) {
+                return $exceptionCheckResult;
+            }
+
+            return $result;
         }
 
         return $this->runChainedSteps($env, $feature, $result, $skip);


### PR DESCRIPTION
This changes the comment syntax in the pretty output to show the actual step that was used instead of the exception check.

If the exception check passes, then return the result from the step that was actually called instead of the exception result.

This will make @stronk7 very happy.

Before:
```
Feature: Use core page resolvers for the I am on the page steps
  In order to write tests correctly
  As a developer
  I need to have steps which take me straight to a page

  Scenario Outline: When I am on a named page # admin/tool/behat/tests/behat/i_am_on_page.feature:58
    Given I log in as "admin"                 # behat_hooks::i_look_for_exceptions()
    When I am on the <identifier> page        # behat_hooks::i_look_for_exceptions()
    Then I should see "<shouldsee>"           # behat_hooks::i_look_for_exceptions()

    Examples:
      | description | identifier            | shouldsee                   |
      | Admin page  | "Admin notifications" | Check for available updates |
      | Home page   | Homepage              | Recently accessed courses   |

2 scenarios (2 passed)
6 steps (6 passed)
0m8.72s (49.46Mb)
```

After:
```
Feature: Use core page resolvers for the I am on the page steps
  In order to write tests correctly
  As a developer
  I need to have steps which take me straight to a page

  Scenario Outline: When I am on a named page # admin/tool/behat/tests/behat/i_am_on_page.feature:58
    Given I log in as "admin"                 # behat_auth::i_log_in_as()
    When I am on the <identifier> page        # behat_navigation::i_am_on_page()
    Then I should see "<shouldsee>"           # behat_general::assert_page_contains_text()

    Examples:
      | description | identifier            | shouldsee                   |
      | Admin page  | "Admin notifications" | Check for available updates |
      | Home page   | Homepage              | Recently accessed courses   |
```