### PR TITLE
Set the default value for Marionette to True

### DIFF
--- a/src/Moodle/BehatExtension/Driver/WebDriverFactory.php
+++ b/src/Moodle/BehatExtension/Driver/WebDriverFactory.php
@@ -62,6 +62,10 @@ class WebDriverFactory extends UpstreamFactory implements DriverFactory {
         // Specify chrome as the default browser.
         $node->find('browser')->defaultValue('chrome');
 
+        // Set the default Marionette value to True.
+        // An empty value here breaks Selenium 4.0 onwards.
+        $node->find('marionette')->defaultTrue();
+
         return $node;
     }
 }


### PR DESCRIPTION
Selenium 4+ validates Capabilities now, and will not accept a Null value
for a Boolean property (marionette).

The real issue here is that the Selenium2Factory is very opionated and
defaults to Firefox with a load of properties.

This is the only one which is really problematic as the rest have either
no default, or sensible defaults.

Where a property has no default, it is considered optional, and is
removed. Where a default is specified, then it will be applied.

There is no way to entirely remove a property once specified using the
Builder. The only way is to specify a new sensible default.